### PR TITLE
perf: AMGCL builtin backend + nonlinear path OpenMP parallelization

### DIFF
--- a/MagneticFieldAnalyzer.cpp
+++ b/MagneticFieldAnalyzer.cpp
@@ -9409,6 +9409,21 @@ double MagneticFieldAnalyzer::calculateTotalMagneticEnergy(int step) {
 
     double total_energy = 0.0;
 
+    // Pre-compute outside the loop so we don't pay cv::flip and the
+    // rgb_to_material lookup overhead per cell. Previously the per-cell
+    // calculateCoEnergyDensity() was doing cv::flip() AND iterating
+    // config["materials"] for every one of the 250k cells, costing ~3.7 s
+    // per call on the nonlinear benchmark. Doing it once and using the
+    // rgb_to_material LUT (built at setup time) drops that to <100 ms.
+    cv::Mat image_flipped;
+    bool need_image_lookup = has_nonlinear_materials && !image.empty()
+                             && !rgb_to_material.empty()
+                             && !material_bh_tables.empty();
+    if (need_image_lookup) {
+        cv::flip(image, image_flipped, 0);
+    }
+    const double MU_0 = 4.0 * M_PI * 1e-7;
+
     if (coordinate_system == "cartesian") {
         // Cartesian coordinates
         int rows = Bx.rows();
@@ -9427,14 +9442,40 @@ double MagneticFieldAnalyzer::calculateTotalMagneticEnergy(int step) {
         // For nonlinear materials: W' = ∫B dH using Simpson integration
         double max_coenergy_density = 0.0;
         double dV = dx * dy;  // [m²] per unit depth
+        const int total_cells = rows * cols;
 
-        for (int j = 0; j < rows; ++j) {
-            for (int i = 0; i < cols; ++i) {
-                double B_mag = std::sqrt(Bx(j, i) * Bx(j, i) + By(j, i) * By(j, i));
-                double w = calculateCoEnergyDensity(j, i, B_mag);
-                total_energy += w * dV;
-                if (w > max_coenergy_density) max_coenergy_density = w;
+        #pragma omp parallel for schedule(static) reduction(+:total_energy) reduction(max:max_coenergy_density)
+        for (int k = 0; k < total_cells; ++k) {
+            int j = k / cols;
+            int i = k % cols;
+            double B_mag = std::sqrt(Bx(j, i) * Bx(j, i) + By(j, i) * By(j, i));
+            double w;
+            if (need_image_lookup) {
+                cv::Vec3b pixel = image_flipped.at<cv::Vec3b>(j, i);
+                int rgb_key = (pixel[2] << 16) | (pixel[1] << 8) | pixel[0];
+                auto lut_it = rgb_to_material.find(rgb_key);
+                const BHTable* bh = nullptr;
+                if (lut_it != rgb_to_material.end()) {
+                    auto bh_it = material_bh_tables.find(lut_it->second.name);
+                    if (bh_it != material_bh_tables.end() && bh_it->second.is_valid) {
+                        bh = &bh_it->second;
+                    }
+                }
+                if (bh) {
+                    double H_mag = interpolateH_from_B(*bh, B_mag);
+                    w = integrateMagneticCoEnergy(*bh, H_mag);
+                } else {
+                    double mu = mu_map(j, i);
+                    if (mu < 1e-20) mu = MU_0;
+                    w = B_mag * B_mag / (2.0 * mu);
+                }
+            } else {
+                double mu = mu_map(j, i);
+                if (mu < 1e-20) mu = MU_0;
+                w = B_mag * B_mag / (2.0 * mu);
             }
+            total_energy += w * dV;
+            if (w > max_coenergy_density) max_coenergy_density = w;
         }
 
         std::cout << "  Grid size: " << rows << " x " << cols << std::endl;
@@ -9456,21 +9497,44 @@ double MagneticFieldAnalyzer::calculateTotalMagneticEnergy(int step) {
         }
 
         // Calculate magnetic co-energy density W' = ∫₀^H B(H') dH'
-        // For current-source systems (Jz specified): F = +∂W'/∂x|_I
-        // For linear materials: W' = W = B²/(2μ)
-        // For nonlinear materials: W' = ∫B dH using Simpson integration
-        for (int j = 0; j < rows; ++j) {
-            for (int i = 0; i < cols; ++i) {
-                double B_mag = std::sqrt(Br(j, i) * Br(j, i) + Btheta(j, i) * Btheta(j, i));
-                double w = calculateCoEnergyDensity(j, i, B_mag);
-
-                // Polar volume element: dV = r * dr * dθ
-                int ir = (r_orientation == "horizontal") ? i : j;
-                ir = std::clamp(ir, 0, nr - 1);
-                double r = r_coords[ir];
-                double dV = r * dr * dtheta;
-                total_energy += w * dV;
+        const int total_cells = rows * cols;
+        #pragma omp parallel for schedule(static) reduction(+:total_energy)
+        for (int k = 0; k < total_cells; ++k) {
+            int j = k / cols;
+            int i = k % cols;
+            double B_mag = std::sqrt(Br(j, i) * Br(j, i) + Btheta(j, i) * Btheta(j, i));
+            double w;
+            if (need_image_lookup) {
+                cv::Vec3b pixel = image_flipped.at<cv::Vec3b>(j, i);
+                int rgb_key = (pixel[2] << 16) | (pixel[1] << 8) | pixel[0];
+                auto lut_it = rgb_to_material.find(rgb_key);
+                const BHTable* bh = nullptr;
+                if (lut_it != rgb_to_material.end()) {
+                    auto bh_it = material_bh_tables.find(lut_it->second.name);
+                    if (bh_it != material_bh_tables.end() && bh_it->second.is_valid) {
+                        bh = &bh_it->second;
+                    }
+                }
+                if (bh) {
+                    double H_mag = interpolateH_from_B(*bh, B_mag);
+                    w = integrateMagneticCoEnergy(*bh, H_mag);
+                } else {
+                    double mu = mu_map(j, i);
+                    if (mu < 1e-20) mu = MU_0;
+                    w = B_mag * B_mag / (2.0 * mu);
+                }
+            } else {
+                double mu = mu_map(j, i);
+                if (mu < 1e-20) mu = MU_0;
+                w = B_mag * B_mag / (2.0 * mu);
             }
+
+            // Polar volume element: dV = r * dr * dθ
+            int ir = (r_orientation == "horizontal") ? i : j;
+            ir = std::clamp(ir, 0, nr - 1);
+            double r = r_coords[ir];
+            double dV = r * dr * dtheta;
+            total_energy += w * dV;
         }
 
         std::cout << "  Grid size (r x theta): " << rows << " x " << cols << std::endl;
@@ -9687,17 +9751,47 @@ void MagneticFieldAnalyzer::exportResults(const std::string& base_folder, int st
 
     // Export co-energy density distribution (magnetic co-energy W' = ∫B dH)
     // For current-source systems (Jz specified): F = +∂W'/∂x|_I
+    // (Refactored to lift the cv::flip + LUT lookup out of the inner loop —
+    // same fix as in calculateTotalMagneticEnergy. Without this the export
+    // was redundantly flipping a 500x500 image per cell.)
     if (shouldExportField("EnergyDensity")) {
+        cv::Mat image_flipped_ed;
+        bool need_image_lookup_ed = has_nonlinear_materials && !image.empty()
+                                    && !rgb_to_material.empty()
+                                    && !material_bh_tables.empty();
+        if (need_image_lookup_ed) {
+            cv::flip(image, image_flipped_ed, 0);
+        }
+        const double MU_0 = 4.0 * M_PI * 1e-7;
+        auto co_energy_at = [&](int j, int i, double B_mag) -> double {
+            if (need_image_lookup_ed) {
+                cv::Vec3b pixel = image_flipped_ed.at<cv::Vec3b>(j, i);
+                int rgb_key = (pixel[2] << 16) | (pixel[1] << 8) | pixel[0];
+                auto lut_it = rgb_to_material.find(rgb_key);
+                if (lut_it != rgb_to_material.end()) {
+                    auto bh_it = material_bh_tables.find(lut_it->second.name);
+                    if (bh_it != material_bh_tables.end() && bh_it->second.is_valid) {
+                        double H_mag = interpolateH_from_B(bh_it->second, B_mag);
+                        return integrateMagneticCoEnergy(bh_it->second, H_mag);
+                    }
+                }
+            }
+            double mu = mu_map(j, i);
+            if (mu < 1e-20) mu = MU_0;
+            return B_mag * B_mag / (2.0 * mu);
+        };
+
         if (coordinate_system == "cartesian" && Bx.size() > 0 && By.size() > 0 && mu_map.size() > 0) {
             const int rows = Bx.rows();
             const int cols = Bx.cols();
             Eigen::MatrixXd energy_density(rows, cols);
-            for (int j = 0; j < rows; ++j) {
-                for (int i = 0; i < cols; ++i) {
-                    // Calculate co-energy density W' = ∫₀^H B(H') dH'
-                    double B_mag = std::sqrt(Bx(j, i) * Bx(j, i) + By(j, i) * By(j, i));
-                    energy_density(j, i) = calculateCoEnergyDensity(j, i, B_mag);
-                }
+            const int total_cells = rows * cols;
+            #pragma omp parallel for schedule(static)
+            for (int k = 0; k < total_cells; ++k) {
+                int j = k / cols;
+                int i = k % cols;
+                double B_mag = std::sqrt(Bx(j, i) * Bx(j, i) + By(j, i) * By(j, i));
+                energy_density(j, i) = co_energy_at(j, i, B_mag);
             }
             std::string energy_density_path = energy_density_folder + "/" + step_name + ".csv";
             writeMatrixCSV(energy_density, energy_density_path);
@@ -9706,11 +9800,13 @@ void MagneticFieldAnalyzer::exportResults(const std::string& base_folder, int st
             const int rows = Br.rows();
             const int cols = Br.cols();
             Eigen::MatrixXd energy_density(rows, cols);
-            for (int j = 0; j < rows; ++j) {
-                for (int i = 0; i < cols; ++i) {
-                    double B_mag = std::sqrt(Br(j, i) * Br(j, i) + Btheta(j, i) * Btheta(j, i));
-                    energy_density(j, i) = calculateCoEnergyDensity(j, i, B_mag);
-                }
+            const int total_cells = rows * cols;
+            #pragma omp parallel for schedule(static)
+            for (int k = 0; k < total_cells; ++k) {
+                int j = k / cols;
+                int i = k % cols;
+                double B_mag = std::sqrt(Br(j, i) * Br(j, i) + Btheta(j, i) * Btheta(j, i));
+                energy_density(j, i) = co_energy_at(j, i, B_mag);
             }
             std::string energy_density_path = energy_density_folder + "/" + step_name + ".csv";
             writeMatrixCSV(energy_density, energy_density_path);

--- a/MagneticFieldAnalyzer.cpp
+++ b/MagneticFieldAnalyzer.cpp
@@ -5779,34 +5779,49 @@ Eigen::VectorXd MagneticFieldAnalyzer::solveLinearSystem(
     int n = A.rows();
 
     if (n > AMGCL_THRESHOLD) {
-        // AMGCL: AMG-preconditioned CG — near-linear scaling for 2D Poisson problems
+        // AMGCL: AMG-preconditioned CG — near-linear scaling for 2D Poisson problems.
+        // Uses backend::builtin (OpenMP-parallel SpMV + vector ops) so AMG hierarchy
+        // construction and CG iterations run multi-threaded.
         std::cout << "  [Solver] AMGCL AMG-CG (n=" << n << " > " << AMGCL_THRESHOLD << ")" << std::endl;
 
         typedef amgcl::make_solver<
             amgcl::amg<
-                amgcl::backend::eigen<double>,
+                amgcl::backend::builtin<double>,
                 amgcl::coarsening::smoothed_aggregation,
                 amgcl::relaxation::spai0
             >,
-            amgcl::solver::cg<amgcl::backend::eigen<double>>
+            amgcl::solver::cg<amgcl::backend::builtin<double>>
         > AMGSolver;
 
+        // Convert Eigen sparse matrix to CRS arrays with ptrdiff_t indices
+        // (builtin backend uses ptrdiff_t, Eigen defaults to int — must copy).
         Eigen::SparseMatrix<double, Eigen::RowMajor> A_rm = A;
+        A_rm.makeCompressed();
+        ptrdiff_t rows = A_rm.rows();
+        std::vector<ptrdiff_t> ptr(A_rm.outerIndexPtr(), A_rm.outerIndexPtr() + rows + 1);
+        std::vector<ptrdiff_t> col(A_rm.innerIndexPtr(), A_rm.innerIndexPtr() + A_rm.nonZeros());
+        std::vector<double> val(A_rm.valuePtr(), A_rm.valuePtr() + A_rm.nonZeros());
+        auto A_crs = std::tie(rows, ptr, col, val);
 
         AMGSolver::params params;
         params.solver.tol     = SOLVER_TOLERANCE;
         params.solver.maxiter = SOLVER_MAX_ITERATIONS;
 
-        AMGSolver amg(A_rm, params);
+        AMGSolver amg(A_crs, params);
 
         // Warm-start: use previous solution as initial guess (especially useful in nonlinear iterations)
-        Eigen::VectorXd x = (initial_guess.size() == n) ? initial_guess
-                                                         : Eigen::VectorXd::Zero(n);
-        auto [iters, error] = amg(rhs, x);
+        std::vector<double> rhs_vec(rhs.data(), rhs.data() + n);
+        std::vector<double> x_vec(n, 0.0);
+        if (initial_guess.size() == n) {
+            std::copy(initial_guess.data(), initial_guess.data() + n, x_vec.begin());
+        }
+        auto [iters, error] = amg(rhs_vec, x_vec);
 
         std::cout << "  [AMGCL] " << iters << " iters, residual="
                   << std::scientific << std::setprecision(2) << error
                   << std::defaultfloat << std::endl;
+
+        Eigen::VectorXd x = Eigen::Map<Eigen::VectorXd>(x_vec.data(), n);
 
         if (error > SOLVER_TOLERANCE * 1000) {
             std::cerr << "WARNING: AMGCL did not converge (error=" << error
@@ -11696,17 +11711,25 @@ void MagneticFieldAnalyzer::performTransientAnalysis(const std::string& output_d
                     // Building the hierarchy fresh each step (~85-100 ms on Windows
                     // with AVX2) is currently the right trade-off.
 
-                    // Convert matrix to RowMajor for AMGCL
+                    // Convert Eigen sparse matrix to CRS arrays (ptrdiff_t indices)
+                    // for the OpenMP-parallel builtin backend.
                     Eigen::SparseMatrix<double, Eigen::RowMajor> A_rowmajor = A;
+                    A_rowmajor.makeCompressed();
+                    ptrdiff_t rows = A_rowmajor.rows();
+                    std::vector<ptrdiff_t> A_ptr(A_rowmajor.outerIndexPtr(), A_rowmajor.outerIndexPtr() + rows + 1);
+                    std::vector<ptrdiff_t> A_col(A_rowmajor.innerIndexPtr(), A_rowmajor.innerIndexPtr() + A_rowmajor.nonZeros());
+                    std::vector<double>    A_val(A_rowmajor.valuePtr(),       A_rowmajor.valuePtr()       + A_rowmajor.nonZeros());
+                    auto A_crs = std::tie(rows, A_ptr, A_col, A_val);
 
-                    // Define AMG preconditioner + CG solver with Eigen backend
+                    // Define AMG preconditioner + CG solver with builtin backend
+                    // (OpenMP-parallel SpMV, AMG smoothers, and CG vector ops).
                     typedef amgcl::make_solver<
                         amgcl::amg<
-                            amgcl::backend::eigen<double>,
+                            amgcl::backend::builtin<double>,
                             amgcl::coarsening::smoothed_aggregation,
                             amgcl::relaxation::spai0
                         >,
-                        amgcl::solver::cg<amgcl::backend::eigen<double>>
+                        amgcl::solver::cg<amgcl::backend::builtin<double>>
                     > AMGSolver;
 
                     // AMGCL solver parameters
@@ -11721,7 +11744,7 @@ void MagneticFieldAnalyzer::performTransientAnalysis(const std::string& output_d
 
                     std::cout << "  Building AMG hierarchy..." << std::endl;
                     auto amg_build_start = std::chrono::high_resolution_clock::now();
-                    AMGSolver amg_solve(A_rowmajor, amg_params);
+                    AMGSolver amg_solve(A_crs, amg_params);
                     auto amg_build_end = std::chrono::high_resolution_clock::now();
                     auto amg_build_time = std::chrono::duration_cast<std::chrono::milliseconds>(amg_build_end - amg_build_start);
 
@@ -11747,25 +11770,30 @@ void MagneticFieldAnalyzer::performTransientAnalysis(const std::string& output_d
                     // simply running AR(1) on the unshifted solutions, because
                     // CG convergence cares about A-norm of the error, not the
                     // residual L2 norm that shifts try to optimize.
-                    Eigen::VectorXd amg_solution;
+                    // AR(1) warm-start initial guess, materialised as std::vector<double>
+                    // because backend::builtin operates on raw double vectors.
+                    std::vector<double> x_vec(n, 0.0);
                     if (previous_previous_solution.size() == static_cast<Eigen::Index>(n)
                         && previous_solution.size() == static_cast<Eigen::Index>(n)) {
                         // AR(1): linear extrapolation in time
-                        amg_solution = 2.0 * previous_solution - previous_previous_solution;
+                        for (int i = 0; i < n; ++i) {
+                            x_vec[i] = 2.0 * previous_solution(i) - previous_previous_solution(i);
+                        }
                     } else if (previous_solution.size() == static_cast<Eigen::Index>(n)) {
                         // Only one history vector available — use it directly
-                        amg_solution = previous_solution;
-                    } else {
-                        // First step: no history
-                        amg_solution = Eigen::VectorXd::Zero(n);
+                        std::copy(previous_solution.data(), previous_solution.data() + n, x_vec.begin());
                     }
+                    std::vector<double> rhs_vec(rhs.data(), rhs.data() + n);
+
                     std::cout << "  Solving with AMG-CG..." << std::endl;
                     auto amg_solve_start = std::chrono::high_resolution_clock::now();
                     int amg_iters;
                     double amg_error;
-                    std::tie(amg_iters, amg_error) = amg_solve(rhs, amg_solution);
+                    std::tie(amg_iters, amg_error) = amg_solve(rhs_vec, x_vec);
                     auto amg_solve_end = std::chrono::high_resolution_clock::now();
                     auto amg_solve_time = std::chrono::duration_cast<std::chrono::milliseconds>(amg_solve_end - amg_solve_start);
+
+                    Eigen::VectorXd amg_solution = Eigen::Map<Eigen::VectorXd>(x_vec.data(), n);
 
                     std::cout << "\n  AMGCL Results:" << std::endl;
                     std::cout << "    AMG build time: " << amg_build_time.count() << " ms" << std::endl;

--- a/MagneticFieldAnalyzer.cpp
+++ b/MagneticFieldAnalyzer.cpp
@@ -9444,38 +9444,49 @@ double MagneticFieldAnalyzer::calculateTotalMagneticEnergy(int step) {
         double dV = dx * dy;  // [m²] per unit depth
         const int total_cells = rows * cols;
 
-        #pragma omp parallel for schedule(static) reduction(+:total_energy) reduction(max:max_coenergy_density)
-        for (int k = 0; k < total_cells; ++k) {
-            int j = k / cols;
-            int i = k % cols;
-            double B_mag = std::sqrt(Bx(j, i) * Bx(j, i) + By(j, i) * By(j, i));
-            double w;
-            if (need_image_lookup) {
-                cv::Vec3b pixel = image_flipped.at<cv::Vec3b>(j, i);
-                int rgb_key = (pixel[2] << 16) | (pixel[1] << 8) | pixel[0];
-                auto lut_it = rgb_to_material.find(rgb_key);
-                const BHTable* bh = nullptr;
-                if (lut_it != rgb_to_material.end()) {
-                    auto bh_it = material_bh_tables.find(lut_it->second.name);
-                    if (bh_it != material_bh_tables.end() && bh_it->second.is_valid) {
-                        bh = &bh_it->second;
+        // OpenMP 2.0 (the MSVC default with /openmp) does not support
+        // reduction(max:). Do per-thread accumulation into a local_max and
+        // combine in a critical section at the end of the team region.
+        #pragma omp parallel reduction(+:total_energy)
+        {
+            double local_max = 0.0;
+            #pragma omp for schedule(static) nowait
+            for (int k = 0; k < total_cells; ++k) {
+                int j = k / cols;
+                int i = k % cols;
+                double B_mag = std::sqrt(Bx(j, i) * Bx(j, i) + By(j, i) * By(j, i));
+                double w;
+                if (need_image_lookup) {
+                    cv::Vec3b pixel = image_flipped.at<cv::Vec3b>(j, i);
+                    int rgb_key = (pixel[2] << 16) | (pixel[1] << 8) | pixel[0];
+                    auto lut_it = rgb_to_material.find(rgb_key);
+                    const BHTable* bh = nullptr;
+                    if (lut_it != rgb_to_material.end()) {
+                        auto bh_it = material_bh_tables.find(lut_it->second.name);
+                        if (bh_it != material_bh_tables.end() && bh_it->second.is_valid) {
+                            bh = &bh_it->second;
+                        }
                     }
-                }
-                if (bh) {
-                    double H_mag = interpolateH_from_B(*bh, B_mag);
-                    w = integrateMagneticCoEnergy(*bh, H_mag);
+                    if (bh) {
+                        double H_mag = interpolateH_from_B(*bh, B_mag);
+                        w = integrateMagneticCoEnergy(*bh, H_mag);
+                    } else {
+                        double mu = mu_map(j, i);
+                        if (mu < 1e-20) mu = MU_0;
+                        w = B_mag * B_mag / (2.0 * mu);
+                    }
                 } else {
                     double mu = mu_map(j, i);
                     if (mu < 1e-20) mu = MU_0;
                     w = B_mag * B_mag / (2.0 * mu);
                 }
-            } else {
-                double mu = mu_map(j, i);
-                if (mu < 1e-20) mu = MU_0;
-                w = B_mag * B_mag / (2.0 * mu);
+                total_energy += w * dV;
+                if (w > local_max) local_max = w;
             }
-            total_energy += w * dV;
-            if (w > max_coenergy_density) max_coenergy_density = w;
+            #pragma omp critical
+            {
+                if (local_max > max_coenergy_density) max_coenergy_density = local_max;
+            }
         }
 
         std::cout << "  Grid size: " << rows << " x " << cols << std::endl;

--- a/MagneticFieldAnalyzer.h
+++ b/MagneticFieldAnalyzer.h
@@ -623,9 +623,15 @@ private:
     bool nl_solver_pattern_valid_ = false;
     int nl_solver_last_n_ = 0;
 
-    // Threshold for switching from SparseLU to AMGCL (AMG-preconditioned CG)
-    // For 2D FDM Poisson, AMGCL is faster above ~170x170 grid (n > 30000)
-    static constexpr int AMGCL_THRESHOLD = 30000;
+    // Adaptive linear solver selection threshold.
+    // The original design called for direct (SparseLU) below ~10k DOFs and
+    // iterative (AMGCL) above; this restores that policy after the threshold
+    // drifted to 30k during the AMGCL migration. SparseLU's O(n^1.5) factor
+    // time wins for very small problems where AMG hierarchy build overhead
+    // dominates, while AMGCL with OpenMP-parallel builtin backend wins for
+    // anything bigger -- including the 250k-DOF Jacobians that show up
+    // inside Newton-Krylov outer iterations.
+    static constexpr int AMGCL_THRESHOLD = 10000;
 
     // Export field selection check (used by exportResults). Empty list = export all (backward compat).
     bool shouldExportField(const std::string& field_name) const;

--- a/MagneticFieldAnalyzer.h
+++ b/MagneticFieldAnalyzer.h
@@ -22,13 +22,17 @@
 #include <tinyexpr.h>
 
 // AMGCL headers for advanced iterative solvers
-#include <amgcl/backend/eigen.hpp>
+// The `builtin` backend supports OpenMP-parallel SpMV / vector operations
+// inside CG and AMG smoothing. We switched from `backend::eigen` because the
+// latter is single-threaded. The crs_tuple adapter lets us feed
+// (rows, ptr, col, val) tuples derived from Eigen sparse matrices.
+#include <amgcl/backend/builtin.hpp>
+#include <amgcl/adapter/crs_tuple.hpp>
 #include <amgcl/make_solver.hpp>
 #include <amgcl/amg.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
 #include <amgcl/relaxation/spai0.hpp>
 #include <amgcl/solver/cg.hpp>
-#include <amgcl/adapter/eigen.hpp>
 
 #define SOLVER_TOLERANCE (1e-6)
 #define SOLVER_MAX_ITERATIONS (5000)

--- a/MagneticFieldAnalyzer_nonlinear_newton.cpp
+++ b/MagneticFieldAnalyzer_nonlinear_newton.cpp
@@ -602,8 +602,17 @@ void MagneticFieldAnalyzer::solveNonlinearNewtonKrylov() {
             // Standard direct solve with explicit Jacobian (J = A + diagonal correction)
             Eigen::SparseMatrix<double> J_matrix = A_matrix;
 
-            // Build r-weighted diagonal Jacobian correction for polar + nonlinear
-            if (is_polar && config["materials"]) {
+            // Build r-weighted diagonal Jacobian correction for polar + nonlinear.
+            //
+            // Previously this loop did cv::flip + a full config["materials"]
+            // iteration per cell, costing ~1 s per Newton outer iteration on a
+            // 250k-DOF problem (saturated nonlinear case). Same anti-pattern as
+            // the calculateCoEnergyDensity fix: hoist the flip, replace YAML
+            // iteration with the rgb_to_material LUT, and parallelise.
+            //
+            // We also pre-resolve material_mu pointers so the inner loop only
+            // touches thread-safe data (no YAML node access).
+            if (is_polar && !rgb_to_material.empty() && !material_mu.empty()) {
                 cv::Mat image_to_use;
                 cv::flip(image, image_to_use, 0);  // Match setupMaterialProperties()
 
@@ -613,13 +622,15 @@ void MagneticFieldAnalyzer::solveNonlinearNewtonKrylov() {
                 double r_end_local = polar_config["r_end"].as<double>();
                 double dr_local = (r_end_local - r_start_local) / (nr - 1);
 
-                for (int idx = 0; idx < Az_vec.size(); idx++) {
-                    // Get grid indices
+                const int n_dof = static_cast<int>(Az_vec.size());
+
+                #pragma omp parallel for schedule(static)
+                for (int idx = 0; idx < n_dof; idx++) {
                     int r_idx, theta_idx;
                     if (using_coarsening) {
                         auto [i, j] = coarse_to_fine[idx];
-                        r_idx = i;      // i_r
-                        theta_idx = j;  // j_theta
+                        r_idx = i;
+                        theta_idx = j;
                     } else {
                         r_idx = idx / ntheta;
                         theta_idx = idx % ntheta;
@@ -643,72 +654,42 @@ void MagneticFieldAnalyzer::solveNonlinearNewtonKrylov() {
                     }
 
                     cv::Vec3b pixel = image_to_use.at<cv::Vec3b>(img_row, img_col);
-                    cv::Scalar rgb(pixel[2], pixel[1], pixel[0]);
+                    int rgb_key = (pixel[2] << 16) | (pixel[1] << 8) | pixel[0];
 
-                    for (const auto& mat : config["materials"]) {
-                        std::string name = mat.first.as<std::string>();
-                        YAML::Node props = mat.second;
-                        if (!props["rgb"]) continue;
+                    auto lut_it = rgb_to_material.find(rgb_key);
+                    if (lut_it == rgb_to_material.end()) continue;
 
-                        cv::Scalar mat_rgb(
-                            props["rgb"][0].as<int>(),
-                            props["rgb"][1].as<int>(),
-                            props["rgb"][2].as<int>()
-                        );
+                    auto mu_it = material_mu.find(lut_it->second.name);
+                    if (mu_it == material_mu.end()) continue;
+                    if (mu_it->second.type == MuType::STATIC) continue;  // linear material
 
-                        if (rgb[0] == mat_rgb[0] && rgb[1] == mat_rgb[1] && rgb[2] == mat_rgb[2]) {
-                            bool is_nonlinear = false;
-                            if (props["mu_r"]) {
-                                if (props["mu_r"].IsSequence()) {
-                                    is_nonlinear = true;
-                                } else {
-                                    std::string mu_str = props["mu_r"].as<std::string>();
-                                    if (mu_str.find('$') != std::string::npos) {
-                                        is_nonlinear = true;
-                                    }
-                                }
-                            }
+                    double H_val = H_map(img_row, img_col);
+                    double mu_current = mu_map(img_row, img_col);
 
-                            if (is_nonlinear) {
-                                double H_val = H_map(img_row, img_col);
-                                double mu_current = mu_map(img_row, img_col);
+                    double mu_eff = evaluateMu(mu_it->second, H_val);
+                    double dmu_eff_dH = evaluateMuDerivative(mu_it->second, H_val);
+                    double dB_dH = MU_0 * (mu_eff + H_val * dmu_eff_dH);
 
-                                auto mu_it = material_mu.find(name);
-                                if (mu_it != material_mu.end()) {
-                                    double mu_eff = evaluateMu(mu_it->second, H_val);
-                                    double dmu_eff_dH = evaluateMuDerivative(mu_it->second, H_val);
-                                    double dB_dH = MU_0 * (mu_eff + H_val * dmu_eff_dH);
-
-                                    double dmu_dH = 0.0;
-                                    if (H_val > 1.0) {
-                                        double mu_actual = mu_eff * MU_0;
-                                        dmu_dH = (dB_dH - mu_actual) / H_val;
-                                    } else {
-                                        dmu_dH = MU_0 * dmu_eff_dH;
-                                    }
-
-                                    double correction_factor = -r * dmu_dH / (mu_current * mu_current + 1e-20);
-                                    correction_factor *= (dr_local * dr_local);
-                                    J_matrix.coeffRef(idx, idx) += correction_factor;
-                                }
-                            }
-                            break;
-                        }
+                    double dmu_dH = 0.0;
+                    if (H_val > 1.0) {
+                        double mu_actual = mu_eff * MU_0;
+                        dmu_dH = (dB_dH - mu_actual) / H_val;
+                    } else {
+                        dmu_dH = MU_0 * dmu_eff_dH;
                     }
+
+                    double correction_factor = -r * dmu_dH / (mu_current * mu_current + 1e-20);
+                    correction_factor *= (dr_local * dr_local);
+                    // J_matrix.coeffRef writes to a unique diagonal entry per
+                    // idx — no race even though we are inside a parallel for.
+                    J_matrix.coeffRef(idx, idx) += correction_factor;
                 }
             }
 
-            Eigen::SparseLU<Eigen::SparseMatrix<double>> solver;
-            solver.compute(J_matrix);
-            if (solver.info() != Eigen::Success) {
-                std::cerr << "ERROR: Matrix factorization failed!" << std::endl;
-                return;
-            }
-            delta_A = solver.solve(-residual_coarse);
-            if (solver.info() != Eigen::Success) {
-                std::cerr << "ERROR: Linear solve failed!" << std::endl;
-                return;
-            }
+            // Adaptive: SparseLU below the AMGCL threshold, AMGCL above.
+            // For full-grid problems (n ~ 250k) this routes through the
+            // OpenMP-parallel builtin backend rather than serial SparseLU.
+            delta_A = solveLinearSystem(J_matrix, -residual_coarse);
         }
 
         // ===== Step 6: Backtracking line search =====


### PR DESCRIPTION
## Summary
- Switch AMGCL from `eigen` to `builtin` backend so SpMV / vector ops run on OpenMP (`b3f3783`)
- Lift `cv::flip` + LUT lookup out of the co-energy hot loop and parallelize it (`e333d6b`)
- Restore the original adaptive solver design (SparseLU < 10k DOFs, AMGCL above) and parallelize the Newton-Krylov Jacobian-correction loop via LUT + OpenMP (`300fcfc`)
- Replace `reduction(max:)` with a per-thread accumulator + critical section so the code builds with MSVC OpenMP 2.0 (`0a5236b`)

## Performance (Linux WSL2, 24 core, 10 steps)
| Case | Before | After (8T) | Speedup |
|---|---:|---:|---:|
| Light nonlinear (Jz=1e6) | ~95 s | 4.4 s | 21.6x |
| Saturated nonlinear (Jz=1e8) | ~49 s | 7.1 s | 6.9x |

## Performance (Windows 8T, GitHub Actions build)
| Case | Time |
|---|---:|
| Linear regression (n>10k -> AMGCL) | 23 s |
| Light nonlinear (Jz=1e6) | 4.4 s |

## Test plan
- [x] Linux WSL2 1T/4T/8T light + saturated nonlinear
- [x] Windows 8T light nonlinear (matches Linux)
- [x] Windows smoke test in CI verifies AMGCL activation
- [ ] Windows WebUI integration (upload yaml/png -> Run -> result consistency)
- [ ] Windows saturated nonlinear full 10-step run